### PR TITLE
Add zodiac wheel color palette system

### DIFF
--- a/examples/palette_examples.py
+++ b/examples/palette_examples.py
@@ -1,0 +1,38 @@
+"""
+Example: Zodiac Color Palettes
+
+This example demonstrates the different color palettes available for
+the zodiac wheel visualization.
+"""
+
+from datetime import datetime
+
+from starlight import ChartBuilder, draw_chart
+from starlight.visualization import ZodiacPalette
+
+# Create a sample chart
+chart = ChartBuilder.from_native(
+    datetime(1994, 1, 6, 11, 47), "Palo Alto, CA"
+).calculate()
+
+# Generate charts with each palette
+palettes = [
+    (ZodiacPalette.GREY, "Grey (classic)"),
+    (ZodiacPalette.RAINBOW, "Rainbow"),
+    (ZodiacPalette.ELEMENTAL, "Elemental"),
+    (ZodiacPalette.CARDINALITY, "Cardinality"),
+]
+
+print("Generating charts with different zodiac palettes...\n")
+
+for palette, description in palettes:
+    filename = f"examples/chart_examples/palette_{palette.value}.svg"
+    draw_chart(chart, filename=filename, zodiac_palette=palette)
+    print(f"✓ {description:20s} → {filename}")
+
+print("\nAll charts generated successfully!")
+print("\nPalette descriptions:")
+print("  • Grey:        Classic monochrome grey wheel")
+print("  • Rainbow:     Soft 12-color spectrum (Aries=red → Pisces=magenta)")
+print("  • Elemental:   4 colors by element (Fire, Earth, Air, Water)")
+print("  • Cardinality: 3 colors by modality (Cardinal, Fixed, Mutable)")

--- a/src/starlight/visualization/__init__.py
+++ b/src/starlight/visualization/__init__.py
@@ -10,6 +10,7 @@ from .layers import (
     ZodiacLayer,
 )
 from .moon_phase import MoonPhaseLayer
+from .palettes import ZodiacPalette
 
 __all__ = [
     "ChartRenderer",
@@ -20,4 +21,5 @@ __all__ = [
     "PlanetLayer",
     "AspectLayer",
     "MoonPhaseLayer",
+    "ZodiacPalette",
 ]

--- a/src/starlight/visualization/drawing.py
+++ b/src/starlight/visualization/drawing.py
@@ -17,6 +17,7 @@ from .layers import (
     ZodiacLayer,
 )
 from .moon_phase import MoonPhaseLayer
+from .palettes import ZodiacPalette
 
 
 def draw_chart(
@@ -24,6 +25,7 @@ def draw_chart(
     filename: str = "chart.svg",
     size: int = 600,
     moon_phase: bool = True,
+    zodiac_palette: ZodiacPalette | str = ZodiacPalette.GREY,
 ) -> str:
     """
     Draws a standard natal chart.
@@ -36,6 +38,7 @@ def draw_chart(
         filename: The output filename (e.g., "natal_chart.svg").
         size: The pixel dimensions of the (square) chart.
         moon_phase: Whether to show moon phase.
+        zodiac_palette: Color palette for zodiac wheel (grey, rainbow, elemental, cardinality).
 
     Returns:
         The filename of the saved chart.
@@ -61,7 +64,7 @@ def draw_chart(
 
     # Assemble the layers in draw order (background to foreground)
     layers: list[IRenderLayer] = [
-        ZodiacLayer(),
+        ZodiacLayer(palette=zodiac_palette),
         HouseCuspLayer(house_system_name=chart.default_house_system),
         AspectLayer(),
         PlanetLayer(planet_set=planets_to_draw, radius_key="planet_ring"),
@@ -82,11 +85,23 @@ def draw_chart(
 
 
 def draw_chart_with_multiple_houses(
-    chart: CalculatedChart, filename: str = "multi_house_chart.svg", size: int = 600
+    chart: CalculatedChart,
+    filename: str = "multi_house_chart.svg",
+    size: int = 600,
+    zodiac_palette: ZodiacPalette | str = ZodiacPalette.GREY,
 ) -> str:
     """
     Example of the new system's flexibility:
     Draws a natal chart with two house systems overlaid.
+
+    Args:
+        chart: The CalculatedChart object from the ChartBuilder.
+        filename: The output filename.
+        size: The pixel dimensions of the (square) chart.
+        zodiac_palette: Color palette for zodiac wheel (grey, rainbow, elemental, cardinality).
+
+    Returns:
+        The filename of the saved chart.
     """
     asc_object = chart.get_object("ASC")
     rotation_angle = asc_object.longitude if asc_object else 0.0
@@ -111,7 +126,7 @@ def draw_chart_with_multiple_houses(
     system2_name = system_names[1] if len(system_names) > 1 else system_names[0]
 
     layers: list[IRenderLayer] = [
-        ZodiacLayer(),
+        ZodiacLayer(palette=zodiac_palette),
         # --- The only change is here ---
         # Add the first house system (default style)
         HouseCuspLayer(house_system_name=system1_name),

--- a/src/starlight/visualization/palettes.py
+++ b/src/starlight/visualization/palettes.py
@@ -1,0 +1,125 @@
+"""
+Zodiac Color Palettes (starlight.visualization.palettes)
+
+Defines color schemes for the zodiac wheel visualization.
+"""
+
+from enum import Enum
+
+
+class ZodiacPalette(str, Enum):
+    """Available color palettes for the zodiac wheel."""
+
+    GREY = "grey"
+    RAINBOW = "rainbow"
+    ELEMENTAL = "elemental"
+    CARDINALITY = "cardinality"
+
+
+# Zodiac sign properties for palette mapping
+SIGN_ELEMENTS = {
+    0: "fire",  # Aries
+    1: "earth",  # Taurus
+    2: "air",  # Gemini
+    3: "water",  # Cancer
+    4: "fire",  # Leo
+    5: "earth",  # Virgo
+    6: "air",  # Libra
+    7: "water",  # Scorpio
+    8: "fire",  # Sagittarius
+    9: "earth",  # Capricorn
+    10: "air",  # Aquarius
+    11: "water",  # Pisces
+}
+
+SIGN_MODALITIES = {
+    0: "cardinal",  # Aries
+    1: "fixed",  # Taurus
+    2: "mutable",  # Gemini
+    3: "cardinal",  # Cancer
+    4: "fixed",  # Leo
+    5: "mutable",  # Virgo
+    6: "cardinal",  # Libra
+    7: "fixed",  # Scorpio
+    8: "mutable",  # Sagittarius
+    9: "cardinal",  # Capricorn
+    10: "fixed",  # Aquarius
+    11: "mutable",  # Pisces
+}
+
+
+def get_palette_colors(palette: ZodiacPalette) -> list[str]:
+    """
+    Get the color list for a zodiac wheel palette.
+
+    Returns a list of 12 colors (one per sign, starting with Aries).
+
+    Args:
+        palette: The palette to use
+
+    Returns:
+        List of 12 hex color strings
+    """
+    if palette == ZodiacPalette.GREY:
+        # All signs same color (classic grey)
+        return ["#EEEEEE"] * 12
+
+    elif palette == ZodiacPalette.RAINBOW:
+        # Tasteful rainbow: soft, desaturated colors progressing through hue wheel
+        # Starting with Aries (red) and progressing through the spectrum
+        return [
+            "#E8B4B8",  # Aries - soft red
+            "#E8C4B8",  # Taurus - soft orange
+            "#E8D8B8",  # Gemini - soft yellow-orange
+            "#E8E8B8",  # Cancer - soft yellow
+            "#D8E8B8",  # Leo - soft yellow-green
+            "#C4E8B8",  # Virgo - soft green
+            "#B8E8C4",  # Libra - soft cyan-green
+            "#B8E8D8",  # Scorpio - soft cyan
+            "#B8D8E8",  # Sagittarius - soft blue
+            "#B8C4E8",  # Capricorn - soft indigo
+            "#C4B8E8",  # Aquarius - soft violet
+            "#D8B8E8",  # Pisces - soft magenta
+        ]
+
+    elif palette == ZodiacPalette.ELEMENTAL:
+        # 4-color elemental palette
+        element_colors = {
+            "fire": "#F4D4D4",  # Soft warm red
+            "earth": "#D4E4D4",  # Soft green
+            "air": "#D4E4F4",  # Soft blue
+            "water": "#E4D4F4",  # Soft purple
+        }
+        return [element_colors[SIGN_ELEMENTS[i]] for i in range(12)]
+
+    elif palette == ZodiacPalette.CARDINALITY:
+        # 3-color cardinality/modality palette
+        modality_colors = {
+            "cardinal": "#F4E4D4",  # Soft peach (initiating)
+            "fixed": "#D4E4E4",  # Soft teal (sustaining)
+            "mutable": "#E4D4E4",  # Soft lavender (adapting)
+        }
+        return [modality_colors[SIGN_MODALITIES[i]] for i in range(12)]
+
+    else:
+        # Fallback to grey
+        return ["#EEEEEE"] * 12
+
+
+def get_palette_description(palette: ZodiacPalette) -> str:
+    """
+    Get a human-readable description of a palette.
+
+    Args:
+        palette: The palette to describe
+
+    Returns:
+        Description string
+    """
+    descriptions = {
+        ZodiacPalette.GREY: "Classic grey wheel (no color)",
+        ZodiacPalette.RAINBOW: "Rainbow spectrum (12 colors progressing through hue wheel)",
+        ZodiacPalette.ELEMENTAL: "4-color elemental (Fire: red, Earth: green, Air: blue, Water: purple)",
+        ZodiacPalette.CARDINALITY: "3-color modality (Cardinal: peach, Fixed: teal, Mutable: lavender)",
+    }
+    return descriptions.get(palette, "Unknown palette")


### PR DESCRIPTION
Implement 4 color palettes for zodiac wheel visualization:
- Grey: Classic monochrome (default, maintains backward compatibility)
- Rainbow: Tasteful 12-color spectrum progressing through hue wheel
- Elemental: 4 colors by element (Fire/Earth/Air/Water)
- Cardinality: 3 colors by modality (Cardinal/Fixed/Mutable)

Changes:
- Add palettes.py: ZodiacPalette enum and color generation logic
- Update ZodiacLayer: Draw 12 colored wedge segments instead of single ring
- Update draw_chart(): Add zodiac_palette parameter (defaults to grey)
- Export ZodiacPalette from visualization module
- Add palette_examples.py to demonstrate usage

All palettes use soft, desaturated colors for tasteful aesthetics. Users can pass palette as enum or string: ZodiacPalette.RAINBOW or "rainbow"

Example usage:
    draw_chart(chart, zodiac_palette="rainbow")
    draw_chart(chart, zodiac_palette=ZodiacPalette.ELEMENTAL)