### PR TITLE
Replace deprecated draw_chart() functions with new chart.draw() fluent API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,8 +160,9 @@ Presentation/Visualization/Export
 │   │
 │   ├── visualization/         # SVG chart rendering
 │   │   ├── core.py           # ChartRenderer
-│   │   ├── layers.py         # Chart layers (Zodiac, Houses, Planets, etc.)
-│   │   └── draw.py           # High-level draw_chart() function
+│   │   ├── builder.py        # ChartDrawBuilder (fluent API)
+│   │   ├── composer.py       # ChartComposer (orchestrator)
+│   │   └── layers.py         # Chart layers (Zodiac, Houses, Planets, etc.)
 │   │
 │   ├── data/                  # Data registries and notables database
 │   │   └── notables/         # Notable births YAML files
@@ -1012,8 +1013,7 @@ report = (ReportBuilder()
 report.render(format="rich_table")
 
 # Draw chart
-from starlight import draw_chart
-draw_chart(chart, "chart.svg")
+chart.draw("chart.svg").save()
 ```
 
 ### Key Files to Know

--- a/examples/palette_examples.py
+++ b/examples/palette_examples.py
@@ -7,7 +7,7 @@ the zodiac wheel visualization.
 
 from datetime import datetime
 
-from starlight import ChartBuilder, Native, draw_chart
+from starlight import ChartBuilder, Native
 from starlight.visualization import ZodiacPalette
 
 # Create a sample chart
@@ -26,7 +26,7 @@ print("Generating charts with different zodiac palettes...\n")
 
 for palette, description in palettes:
     filename = f"examples/chart_examples/palette_{palette.value}.svg"
-    draw_chart(chart, filename=filename, zodiac_palette=palette)
+    chart.draw(filename).with_zodiac_palette(palette.value).save()
     print(f"✓ {description:20s} → {filename}")
 
 print("\nAll charts generated successfully!")

--- a/examples/test_biwheel.py
+++ b/examples/test_biwheel.py
@@ -8,7 +8,7 @@ Tests the new draw_comparison_chart function with a synastry example.
 from datetime import datetime
 import datetime as dt
 
-from starlight import ChartBuilder, ComparisonBuilder, draw_comparison_chart
+from starlight import ChartBuilder, ComparisonBuilder
 from starlight.core.models import ChartLocation
 
 
@@ -33,13 +33,11 @@ def test_basic_synastry():
     )
 
     # Draw bi-wheel chart
-    draw_comparison_chart(
-        synastry,
-        filename="examples/chart_examples/biwheel_synastry_basic.svg",
-        theme="classic",
-        extended_canvas="right",
-        show_position_table=True,
-        show_aspectarian=True,
+    (
+        synastry.draw("examples/chart_examples/biwheel_synastry_basic.svg")
+        .with_theme("classic")
+        .with_tables(position="right", show_position_table=True, show_aspectarian=True)
+        .save()
     )
 
     print("✓ Generated: biwheel_synastry_basic.svg")
@@ -61,20 +59,20 @@ def test_synastry_themes():
     )
 
     # Dark theme
-    draw_comparison_chart(
-        synastry,
-        filename="examples/chart_examples/biwheel_synastry_dark.svg",
-        theme="dark",
-        extended_canvas="right",
+    (
+        synastry.draw("examples/chart_examples/biwheel_synastry_dark.svg")
+        .with_theme("dark")
+        .with_tables(position="right")
+        .save()
     )
     print("✓ Generated: biwheel_synastry_dark.svg (dark theme)")
 
     # Midnight theme
-    draw_comparison_chart(
-        synastry,
-        filename="examples/chart_examples/biwheel_synastry_midnight.svg",
-        theme="midnight",
-        extended_canvas="right",
+    (
+        synastry.draw("examples/chart_examples/biwheel_synastry_midnight.svg")
+        .with_theme("midnight")
+        .with_tables(position="right")
+        .save()
     )
     print("✓ Generated: biwheel_synastry_midnight.svg (midnight theme)")
 
@@ -93,20 +91,20 @@ def test_extended_canvas_positions():
     )
 
     # Extended canvas on left
-    draw_comparison_chart(
-        synastry,
-        filename="examples/chart_examples/biwheel_extended_left.svg",
-        extended_canvas="left",
-        theme="classic",
+    (
+        synastry.draw("examples/chart_examples/biwheel_extended_left.svg")
+        .with_tables(position="left")
+        .with_theme("classic")
+        .save()
     )
     print("✓ Generated: biwheel_extended_left.svg")
 
     # Extended canvas below
-    draw_comparison_chart(
-        synastry,
-        filename="examples/chart_examples/biwheel_extended_below.svg",
-        extended_canvas="below",
-        theme="classic",
+    (
+        synastry.draw("examples/chart_examples/biwheel_extended_below.svg")
+        .with_tables(position="below")
+        .with_theme("classic")
+        .save()
     )
     print("✓ Generated: biwheel_extended_below.svg")
 

--- a/examples/test_chart_info.py
+++ b/examples/test_chart_info.py
@@ -10,7 +10,7 @@ Tests:
 """
 
 from datetime import datetime
-from starlight import ChartBuilder, draw_chart
+from starlight import ChartBuilder
 
 
 def test_moon_positions():
@@ -21,33 +21,15 @@ def test_moon_positions():
     chart = ChartBuilder.from_notable("Albert Einstein").calculate()
 
     # Test 1: Moon in center (default)
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/moon_center.svg",
-        moon_phase=True,
-        moon_phase_position="center",
-        moon_phase_label=False,
-    )
+    chart.draw("examples/chart_examples/moon_center.svg").with_moon_phase().save()
     print("✓ Generated: moon_center.svg")
 
     # Test 2: Moon in top-right with label
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/moon_top_right_labeled.svg",
-        moon_phase=True,
-        moon_phase_position="top-right",
-        moon_phase_label=True,
-    )
+    chart.draw("examples/chart_examples/moon_top_right_labeled.svg").with_moon_phase().save()
     print("✓ Generated: moon_top_right_labeled.svg")
 
     # Test 3: Moon in bottom-left with label
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/moon_bottom_left_labeled.svg",
-        moon_phase=True,
-        moon_phase_position="bottom-left",
-        moon_phase_label=True,
-    )
+    chart.draw("examples/chart_examples/moon_bottom_left_labeled.svg").with_moon_phase().save()
     print("✓ Generated: moon_bottom_left_labeled.svg")
 
 
@@ -58,22 +40,20 @@ def test_chart_info():
     chart = ChartBuilder.from_notable("Albert Einstein").calculate()
 
     # Test 4: Chart info in top-left
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/chart_info_top_left.svg",
-        moon_phase=False,
-        chart_info=True,
-        chart_info_position="top-left",
+    (
+        chart.draw("examples/chart_examples/chart_info_top_left.svg")
+        .without_moon_phase()
+        .with_chart_info()
+        .save()
     )
     print("✓ Generated: chart_info_top_left.svg")
 
     # Test 5: Chart info in top-right
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/chart_info_top_right.svg",
-        moon_phase=False,
-        chart_info=True,
-        chart_info_position="top-right",
+    (
+        chart.draw("examples/chart_examples/chart_info_top_right.svg")
+        .without_moon_phase()
+        .with_chart_info()
+        .save()
     )
     print("✓ Generated: chart_info_top_right.svg")
 
@@ -85,27 +65,21 @@ def test_combined():
     chart = ChartBuilder.from_notable("Albert Einstein").calculate()
 
     # Test 6: Moon in bottom-right, chart info in top-left
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/combined_moon_and_info.svg",
-        moon_phase=True,
-        moon_phase_position="bottom-right",
-        moon_phase_label=True,
-        chart_info=True,
-        chart_info_position="top-left",
+    (
+        chart.draw("examples/chart_examples/combined_moon_and_info.svg")
+        .with_moon_phase()
+        .with_chart_info()
+        .save()
     )
     print("✓ Generated: combined_moon_and_info.svg")
 
     # Test 7: Moon in top-right, chart info in top-left (showing full aspect lines)
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/moon_corner_full_aspects.svg",
-        moon_phase=True,
-        moon_phase_position="top-right",
-        moon_phase_label=True,
-        chart_info=True,
-        chart_info_position="top-left",
-        theme="dark",
+    (
+        chart.draw("examples/chart_examples/moon_corner_full_aspects.svg")
+        .with_theme("dark")
+        .with_moon_phase()
+        .with_chart_info()
+        .save()
     )
     print("✓ Generated: moon_corner_full_aspects.svg (with dark theme)")
 
@@ -117,16 +91,12 @@ def test_notable():
     chart = ChartBuilder.from_notable("Albert Einstein").calculate()
 
     # Test 8: Full-featured chart with notable
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/einstein_full_featured.svg",
-        moon_phase=True,
-        moon_phase_position="bottom-right",
-        moon_phase_label=True,
-        chart_info=True,
-        chart_info_position="top-left",
-        chart_info_fields=["name", "location", "datetime", "coordinates"],
-        theme="midnight",
+    (
+        chart.draw("examples/chart_examples/einstein_full_featured.svg")
+        .with_theme("midnight")
+        .with_moon_phase()
+        .with_chart_info()
+        .save()
     )
     print("✓ Generated: einstein_full_featured.svg")
 

--- a/examples/test_corner_layers.py
+++ b/examples/test_corner_layers.py
@@ -9,7 +9,7 @@ Tests:
 4. All corners occupied with auto-padding
 """
 
-from starlight import ChartBuilder, draw_chart
+from starlight import ChartBuilder
 
 
 def test_individual_corners():
@@ -19,32 +19,29 @@ def test_individual_corners():
     chart = ChartBuilder.from_notable("Albert Einstein").calculate()
 
     # Test 1: Aspect counts only
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/test_aspect_counts.svg",
-        moon_phase=False,
-        aspect_counts=True,
-        aspect_counts_position="top-right",
+    (
+        chart.draw("examples/chart_examples/test_aspect_counts.svg")
+        .without_moon_phase()
+        .with_aspect_counts()
+        .save()
     )
     print("✓ Generated: test_aspect_counts.svg")
 
     # Test 2: Element/modality table only
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/test_element_modality.svg",
-        moon_phase=False,
-        element_modality_table=True,
-        element_modality_position="bottom-left",
+    (
+        chart.draw("examples/chart_examples/test_element_modality.svg")
+        .without_moon_phase()
+        .with_element_modality_table()
+        .save()
     )
     print("✓ Generated: test_element_modality.svg")
 
     # Test 3: Chart shape only
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/test_chart_shape.svg",
-        moon_phase=False,
-        chart_shape=True,
-        chart_shape_position="bottom-right",
+    (
+        chart.draw("examples/chart_examples/test_chart_shape.svg")
+        .without_moon_phase()
+        .with_chart_shape()
+        .save()
     )
     print("✓ Generated: test_chart_shape.svg")
 
@@ -56,38 +53,25 @@ def test_multiple_corners():
     chart = ChartBuilder.from_notable("Albert Einstein").calculate()
 
     # Test 4: All four corners occupied
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/test_all_four_corners.svg",
-        moon_phase=True,
-        moon_phase_position="center",  # Keep moon in center
-        chart_info=True,
-        chart_info_position="top-left",
-        aspect_counts=True,
-        aspect_counts_position="top-right",
-        element_modality_table=True,
-        element_modality_position="bottom-left",
-        chart_shape=True,
-        chart_shape_position="bottom-right",
-        auto_padding=True,  # Should apply padding
+    (
+        chart.draw("examples/chart_examples/test_all_four_corners.svg")
+        .with_moon_phase()
+        .with_chart_info()
+        .with_aspect_counts()
+        .with_element_modality_table()
+        .with_chart_shape()
+        .save()
     )
     print("✓ Generated: test_all_four_corners.svg (with auto-padding)")
 
     # Test 5: All corners + moon in corner
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/test_all_corners_moon_aside.svg",
-        moon_phase=True,
-        moon_phase_position="top-right",
-        moon_phase_label=True,
-        chart_info=True,
-        chart_info_position="top-left",
-        aspect_counts=False,  # Skip aspect counts to make room for moon
-        element_modality_table=True,
-        element_modality_position="bottom-left",
-        chart_shape=True,
-        chart_shape_position="bottom-right",
-        auto_padding=True,
+    (
+        chart.draw("examples/chart_examples/test_all_corners_moon_aside.svg")
+        .with_moon_phase()
+        .with_chart_info()
+        .with_element_modality_table()
+        .with_chart_shape()
+        .save()
     )
     print("✓ Generated: test_all_corners_moon_aside.svg")
 
@@ -99,37 +83,28 @@ def test_themed_corners():
     chart = ChartBuilder.from_notable("Marie Curie").calculate()
 
     # Test 6: Dark theme with all corners
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/test_dark_all_corners.svg",
-        theme="dark",
-        moon_phase=True,
-        moon_phase_position="center",
-        chart_info=True,
-        chart_info_position="top-left",
-        aspect_counts=True,
-        aspect_counts_position="top-right",
-        element_modality_table=True,
-        element_modality_position="bottom-left",
-        chart_shape=True,
-        chart_shape_position="bottom-right",
+    (
+        chart.draw("examples/chart_examples/test_dark_all_corners.svg")
+        .with_theme("dark")
+        .with_moon_phase()
+        .with_chart_info()
+        .with_aspect_counts()
+        .with_element_modality_table()
+        .with_chart_shape()
+        .save()
     )
     print("✓ Generated: test_dark_all_corners.svg (dark theme)")
 
     # Test 7: Midnight theme with all corners
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/test_midnight_all_corners.svg",
-        theme="midnight",
-        moon_phase=False,
-        chart_info=True,
-        chart_info_position="top-left",
-        aspect_counts=True,
-        aspect_counts_position="top-right",
-        element_modality_table=True,
-        element_modality_position="bottom-left",
-        chart_shape=True,
-        chart_shape_position="bottom-right",
+    (
+        chart.draw("examples/chart_examples/test_midnight_all_corners.svg")
+        .with_theme("midnight")
+        .without_moon_phase()
+        .with_chart_info()
+        .with_aspect_counts()
+        .with_element_modality_table()
+        .with_chart_shape()
+        .save()
     )
     print("✓ Generated: test_midnight_all_corners.svg (midnight theme)")
 

--- a/examples/test_extended_canvas.py
+++ b/examples/test_extended_canvas.py
@@ -11,7 +11,7 @@ Tests:
 6. Extended canvas with different themes
 """
 
-from starlight import ChartBuilder, draw_chart
+from starlight import ChartBuilder
 
 
 def test_extended_right():
@@ -20,13 +20,11 @@ def test_extended_right():
 
     chart = ChartBuilder.from_notable("Albert Einstein").calculate()
 
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/extended_right.svg",
-        extended_canvas="right",
-        show_position_table=True,
-        show_aspectarian=True,
-        moon_phase=False,
+    (
+        chart.draw("examples/chart_examples/extended_right.svg")
+        .without_moon_phase()
+        .with_tables(position="right", show_position_table=True, show_aspectarian=True)
+        .save()
     )
     print("✓ Generated: extended_right.svg")
 
@@ -37,13 +35,11 @@ def test_extended_left():
 
     chart = ChartBuilder.from_notable("Marie Curie").calculate()
 
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/extended_left.svg",
-        extended_canvas="left",
-        show_position_table=True,
-        show_aspectarian=True,
-        moon_phase=False,
+    (
+        chart.draw("examples/chart_examples/extended_left.svg")
+        .without_moon_phase()
+        .with_tables(position="left", show_position_table=True, show_aspectarian=True)
+        .save()
     )
     print("✓ Generated: extended_left.svg")
 
@@ -54,13 +50,11 @@ def test_extended_below():
 
     chart = ChartBuilder.from_notable("Frida Kahlo").calculate()
 
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/extended_below.svg",
-        extended_canvas="below",
-        show_position_table=True,
-        show_aspectarian=True,
-        moon_phase=False,
+    (
+        chart.draw("examples/chart_examples/extended_below.svg")
+        .without_moon_phase()
+        .with_tables(position="below", show_position_table=True, show_aspectarian=True)
+        .save()
     )
     print("✓ Generated: extended_below.svg")
 
@@ -72,26 +66,22 @@ def test_extended_with_themes():
     chart = ChartBuilder.from_notable("Albert Einstein").calculate()
 
     # Dark theme
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/extended_dark.svg",
-        extended_canvas="right",
-        show_position_table=True,
-        show_aspectarian=True,
-        theme="dark",
-        moon_phase=False,
+    (
+        chart.draw("examples/chart_examples/extended_dark.svg")
+        .with_theme("dark")
+        .without_moon_phase()
+        .with_tables(position="right", show_position_table=True, show_aspectarian=True)
+        .save()
     )
     print("✓ Generated: extended_dark.svg (dark theme)")
 
     # Midnight theme
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/extended_midnight.svg",
-        extended_canvas="right",
-        show_position_table=True,
-        show_aspectarian=True,
-        theme="midnight",
-        moon_phase=False,
+    (
+        chart.draw("examples/chart_examples/extended_midnight.svg")
+        .with_theme("midnight")
+        .without_moon_phase()
+        .with_tables(position="right", show_position_table=True, show_aspectarian=True)
+        .save()
     )
     print("✓ Generated: extended_midnight.svg (midnight theme)")
 
@@ -102,22 +92,15 @@ def test_extended_with_corners():
 
     chart = ChartBuilder.from_notable("Marie Curie").calculate()
 
-    draw_chart(
-        chart,
-        filename="examples/chart_examples/extended_full_featured.svg",
-        extended_canvas="right",
-        show_position_table=True,
-        show_aspectarian=True,
-        chart_info=True,
-        chart_info_position="top-left",
-        aspect_counts=True,
-        aspect_counts_position="top-right",
-        element_modality_table=True,
-        element_modality_position="bottom-left",
-        chart_shape=True,
-        chart_shape_position="bottom-right",
-        moon_phase=True,
-        moon_phase_position="center",
+    (
+        chart.draw("examples/chart_examples/extended_full_featured.svg")
+        .with_moon_phase()
+        .with_chart_info()
+        .with_aspect_counts()
+        .with_element_modality_table()
+        .with_chart_shape()
+        .with_tables(position="right", show_position_table=True, show_aspectarian=True)
+        .save()
     )
     print("✓ Generated: extended_full_featured.svg (all features)")
 

--- a/examples/test_new_theming.py
+++ b/examples/test_new_theming.py
@@ -12,7 +12,6 @@ from datetime import datetime
 
 from starlight import ChartBuilder
 from starlight.core.native import Native
-from starlight.visualization.drawing import draw_chart
 from starlight.visualization.layers import AspectLayer, PlanetLayer, ZodiacLayer
 
 
@@ -28,7 +27,7 @@ def test_data_science_themes():
     for theme in themes:
         print(f"  - Generating chart with {theme} theme...")
         output_file = f"examples/chart_examples/test_{theme}_theme.svg"
-        draw_chart(chart, output_file, theme=theme)
+        chart.draw(output_file).with_theme(theme).save()
 
     print("  ✓ All data science themes generated successfully!")
 
@@ -42,32 +41,32 @@ def test_mix_and_match_palettes():
 
     # Test: Classic theme with rainbow zodiac and viridis aspects
     print("  - Classic theme + rainbow zodiac + viridis aspects...")
-    draw_chart(
-        chart,
-        "examples/chart_examples/test_mix_classic_rainbow_viridis.svg",
-        theme="classic",
-        zodiac_palette="rainbow",
-        aspect_palette="viridis",
+    (
+        chart.draw("examples/chart_examples/test_mix_classic_rainbow_viridis.svg")
+        .with_theme("classic")
+        .with_zodiac_palette("rainbow")
+        .with_aspect_palette("viridis")
+        .save()
     )
 
     # Test: Dark theme with elemental zodiac and plasma aspects
     print("  - Dark theme + elemental zodiac + plasma aspects...")
-    draw_chart(
-        chart,
-        "examples/chart_examples/test_mix_dark_elemental_plasma.svg",
-        theme="dark",
-        zodiac_palette="elemental",
-        aspect_palette="plasma",
+    (
+        chart.draw("examples/chart_examples/test_mix_dark_elemental_plasma.svg")
+        .with_theme("dark")
+        .with_zodiac_palette("elemental")
+        .with_aspect_palette("plasma")
+        .save()
     )
 
     # Test: Midnight theme with viridis zodiac and blues aspects
     print("  - Midnight theme + viridis zodiac + blues aspects...")
-    draw_chart(
-        chart,
-        "examples/chart_examples/test_mix_midnight_viridis_blues.svg",
-        theme="midnight",
-        zodiac_palette="viridis",
-        aspect_palette="blues",
+    (
+        chart.draw("examples/chart_examples/test_mix_midnight_viridis_blues.svg")
+        .with_theme("midnight")
+        .with_zodiac_palette("viridis")
+        .with_aspect_palette("blues")
+        .save()
     )
 
     print("  ✓ Mix-and-match palettes tested successfully!")
@@ -84,11 +83,11 @@ def test_planet_glyph_palettes():
 
     for palette in palettes:
         print(f"  - Generating chart with {palette} planet palette...")
-        draw_chart(
-            chart,
-            f"examples/chart_examples/test_planet_{palette}.svg",
-            theme="dark",
-            planet_glyph_palette=palette,
+        (
+            chart.draw(f"examples/chart_examples/test_planet_{palette}.svg")
+            .with_theme("dark")
+            .with_planet_glyph_palette(palette)
+            .save()
         )
 
     print("  ✓ Planet glyph palettes tested successfully!")
@@ -103,11 +102,11 @@ def test_adaptive_sign_coloring():
 
     # Test with viridis theme and adaptive coloring enabled
     print("  - Viridis theme with adaptive sign coloring...")
-    draw_chart(
-        chart,
-        "examples/chart_examples/test_adaptive_sign_coloring.svg",
-        theme="viridis",
-        color_sign_info=True,
+    (
+        chart.draw("examples/chart_examples/test_adaptive_sign_coloring.svg")
+        .with_theme("viridis")
+        .with_adaptive_colors(sign_info=True)
+        .save()
     )
 
     print("  ✓ Adaptive sign coloring tested successfully!")

--- a/examples/theme_examples.py
+++ b/examples/theme_examples.py
@@ -14,7 +14,7 @@ Each theme provides a cohesive visual style including:
 
 from datetime import datetime
 
-from starlight import ChartBuilder, draw_chart
+from starlight import ChartBuilder
 from starlight.visualization import ChartTheme
 from starlight.visualization.themes import get_theme_description
 
@@ -31,7 +31,7 @@ for theme in ChartTheme:
     description = get_theme_description(theme)
 
     # Draw chart with theme (uses theme's default zodiac palette)
-    draw_chart(chart, filename=filename, theme=theme)
+    chart.draw(filename).with_theme(theme.value).save()
 
     print(f"✓ {description}")
     print(f"  → {filename}\n")
@@ -50,79 +50,79 @@ print("Each theme now has coordinated palette variants that harmonize")
 print("with its color story:\n")
 
 # Dark theme with coordinated palettes
-draw_chart(
-    chart,
-    filename="examples/chart_examples/dark_rainbow_dark.svg",
-    theme="dark",
-    zodiac_palette="rainbow_dark",
+(
+    chart.draw("examples/chart_examples/dark_rainbow_dark.svg")
+    .with_theme("dark")
+    .with_zodiac_palette("rainbow_dark")
+    .save()
 )
 print("✓ Dark theme + Rainbow Dark palette → dark_rainbow_dark.svg")
 
-draw_chart(
-    chart,
-    filename="examples/chart_examples/dark_elemental_dark.svg",
-    theme="dark",
-    zodiac_palette="elemental_dark",
+(
+    chart.draw("examples/chart_examples/dark_elemental_dark.svg")
+    .with_theme("dark")
+    .with_zodiac_palette("elemental_dark")
+    .save()
 )
 print("✓ Dark theme + Elemental Dark palette → dark_elemental_dark.svg")
 
 # Midnight theme with coordinated palettes
-draw_chart(
-    chart,
-    filename="examples/chart_examples/midnight_rainbow_midnight.svg",
-    theme="midnight",
-    zodiac_palette="rainbow_midnight",
+(
+    chart.draw("examples/chart_examples/midnight_rainbow_midnight.svg")
+    .with_theme("midnight")
+    .with_zodiac_palette("rainbow_midnight")
+    .save()
 )
 print("✓ Midnight theme + Rainbow Midnight palette → midnight_rainbow_midnight.svg")
 
-draw_chart(
-    chart,
-    filename="examples/chart_examples/midnight_elemental_midnight.svg",
-    theme="midnight",
-    zodiac_palette="elemental_midnight",
+(
+    chart.draw("examples/chart_examples/midnight_elemental_midnight.svg")
+    .with_theme("midnight")
+    .with_zodiac_palette("elemental_midnight")
+    .save()
 )
 print("✓ Midnight theme + Elemental Midnight palette → midnight_elemental_midnight.svg")
 
 # Neon theme with coordinated palettes
-draw_chart(
-    chart,
-    filename="examples/chart_examples/neon_rainbow_neon.svg",
-    theme="neon",
-    zodiac_palette="rainbow_neon",
+(
+    chart.draw("examples/chart_examples/neon_rainbow_neon.svg")
+    .with_theme("neon")
+    .with_zodiac_palette("rainbow_neon")
+    .save()
 )
 print("✓ Neon theme + Rainbow Neon palette → neon_rainbow_neon.svg")
 
-draw_chart(
-    chart,
-    filename="examples/chart_examples/neon_elemental_neon.svg",
-    theme="neon",
-    zodiac_palette="elemental_neon",
+(
+    chart.draw("examples/chart_examples/neon_elemental_neon.svg")
+    .with_theme("neon")
+    .with_zodiac_palette("elemental_neon")
+    .save()
 )
 print("✓ Neon theme + Elemental Neon palette → neon_elemental_neon.svg")
 
 # Sepia theme with coordinated palettes
-draw_chart(
-    chart,
-    filename="examples/chart_examples/sepia_rainbow_sepia.svg",
-    theme="sepia",
-    zodiac_palette="rainbow_sepia",
+(
+    chart.draw("examples/chart_examples/sepia_rainbow_sepia.svg")
+    .with_theme("sepia")
+    .with_zodiac_palette("rainbow_sepia")
+    .save()
 )
 print("✓ Sepia theme + Rainbow Sepia palette → sepia_rainbow_sepia.svg")
 
-draw_chart(
-    chart,
-    filename="examples/chart_examples/sepia_elemental_sepia.svg",
-    theme="sepia",
-    zodiac_palette="elemental_sepia",
+(
+    chart.draw("examples/chart_examples/sepia_elemental_sepia.svg")
+    .with_theme("sepia")
+    .with_zodiac_palette("elemental_sepia")
+    .save()
 )
 print("✓ Sepia theme + Elemental Sepia palette → sepia_elemental_sepia.svg")
 
 # Celestial theme with coordinated palette
-draw_chart(
-    chart,
-    filename="examples/chart_examples/celestial_rainbow_celestial.svg",
-    theme="celestial",
-    zodiac_palette="rainbow_celestial",
+(
+    chart.draw("examples/chart_examples/celestial_rainbow_celestial.svg")
+    .with_theme("celestial")
+    .with_zodiac_palette("rainbow_celestial")
+    .save()
 )
 print("✓ Celestial theme + Rainbow Celestial palette → celestial_rainbow_celestial.svg")
 
@@ -131,19 +131,19 @@ print("Mix & Match: Custom Combinations")
 print("=" * 70 + "\n")
 
 # You can also mix and match any theme with any palette
-draw_chart(
-    chart,
-    filename="examples/chart_examples/dark_rainbow_base.svg",
-    theme="dark",
-    zodiac_palette="rainbow",
+(
+    chart.draw("examples/chart_examples/dark_rainbow_base.svg")
+    .with_theme("dark")
+    .with_zodiac_palette("rainbow")
+    .save()
 )
 print("✓ Dark theme + Base Rainbow palette → dark_rainbow_base.svg")
 
-draw_chart(
-    chart,
-    filename="examples/chart_examples/midnight_elemental_base.svg",
-    theme="midnight",
-    zodiac_palette="elemental",
+(
+    chart.draw("examples/chart_examples/midnight_elemental_base.svg")
+    .with_theme("midnight")
+    .with_zodiac_palette("elemental")
+    .save()
 )
 print("✓ Midnight theme + Base Elemental palette → midnight_elemental_base.svg")
 

--- a/examples/viz_examples.py
+++ b/examples/viz_examples.py
@@ -22,9 +22,6 @@ from starlight.engines.orbs import LuminariesOrbEngine
 
 # --- Advanced Imports (for Custom Charts) ---
 from starlight.visualization.core import ChartRenderer, IRenderLayer
-
-# --- High-Level Drawing Functions ---
-from starlight.visualization.drawing import draw_chart, draw_chart_with_multiple_houses
 from starlight.visualization.layers import (
     AngleLayer,
     AspectLayer,
@@ -75,7 +72,7 @@ def example_1_standard_natal_chart():
 
     output_path = os.path.join(OUTPUT_DIR, "example_1_natal_chart.svg")
 
-    draw_chart(chart, filename=output_path, size=800)
+    chart.draw(output_path).with_size(800).save()
 
     print(f"✅ Success! Chart saved to {output_path}\n")
 
@@ -83,14 +80,14 @@ def example_1_standard_natal_chart():
 def example_2_multi_house_chart():
     """
     Draws a chart showing two house systems overlaid, using the
-    specialized high-level function.
+    fluent builder API.
     """
     print("Running Example 2: Multi-House Chart...")
     chart = create_sample_chart(multi_house=True)
 
     output_path = os.path.join(OUTPUT_DIR, "example_2_multi_house.svg")
 
-    draw_chart_with_multiple_houses(chart, filename=output_path, size=800)
+    chart.draw(output_path).with_size(800).with_house_systems("all").save()
 
     print(f"✅ Success! Chart saved to {output_path}\n")
 

--- a/src/starlight/__init__.py
+++ b/src/starlight/__init__.py
@@ -2,15 +2,15 @@
 Starlight - Computational Astrology Library
 
 Quick Start:
-    >>> from starlight import ChartBuilder, draw_chart
-    >>> chart = ChartBuilder.from_notable("Albert Einstein").build()
-    >>> draw_chart(chart, "einstein.svg")
+    >>> from starlight import ChartBuilder
+    >>> chart = ChartBuilder.from_notable("Albert Einstein").calculate()
+    >>> chart.draw("einstein.svg").save()
 
 For more control:
     >>> from starlight import ChartBuilder, Native, ReportBuilder
     >>> from starlight.engines import PlacidusHouses, ModernAspectEngine
     >>> native = Native(datetime_input=..., location_input=...)
-    >>> chart = ChartBuilder.from_native(native).build()
+    >>> chart = ChartBuilder.from_native(native).calculate()
 """
 
 __version__ = "0.2.0"
@@ -54,7 +54,6 @@ from starlight.presentation import ReportBuilder
 
 # === Visualization (High-Level) ===
 from starlight.visualization import ChartRenderer
-# draw_chart and draw_comparison_chart don't exist
 
 __all__ = [
     # Version
@@ -77,8 +76,6 @@ __all__ = [
     "get_object_info",
     "get_aspect_info",
     # Visualization
-    # "draw_chart",  # Doesn't exist
-    # "draw_comparison_chart",  # Doesn't exist
     "ChartRenderer",
     # Presentation
     "ReportBuilder",

--- a/src/starlight/cli/chart.py
+++ b/src/starlight/cli/chart.py
@@ -38,7 +38,6 @@ def chart_from_registry_cmd(name, output, house_system, output_format):
     from starlight.core.builder import ChartBuilder
     from starlight.data.registry import get_notable_registry
     from starlight.presentation.builder import ReportBuilder
-    from starlight.visualization.drawing import draw_chart
 
     try:
         registry = get_notable_registry()
@@ -55,7 +54,7 @@ def chart_from_registry_cmd(name, output, house_system, output_format):
 
         if output_format == "svg":
             output_path = output or f"{name.lower().replace(' ', '_')}.svg"
-            draw_chart(chart, output_path)
+            chart.draw(output_path).save()
             click.echo(f"✅ Chart saved to: {output_path}")
 
         elif output_format == "terminal":

--- a/src/starlight/visualization/__init__.py
+++ b/src/starlight/visualization/__init__.py
@@ -2,7 +2,6 @@
 
 from .builder import ChartDrawBuilder
 from .core import ChartRenderer
-# from .drawing import draw_chart, draw_comparison_chart  # Module doesn't exist
 from .extended_canvas import AspectarianLayer, HouseCuspTableLayer, PositionTableLayer
 from .layers import (
     AngleLayer,
@@ -52,8 +51,6 @@ __all__ = [
     # Core rendering
     "ChartRenderer",
     "ChartDrawBuilder",
-    # "draw_chart",  # Module doesn't exist
-    # "draw_comparison_chart",  # Module doesn't exist
     # Layers
     "ZodiacLayer",
     "HouseCuspLayer",

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -30,7 +30,6 @@ from starlight.core.models import (
 from starlight.core.native import Native
 from starlight.engines.houses import PlacidusHouses, WholeSignHouses
 from starlight.visualization.core import ChartRenderer, get_display_name, get_glyph
-from starlight.visualization.drawing import draw_chart
 from starlight.visualization.layers import (
     AngleLayer,
     AspectCountsLayer,
@@ -526,7 +525,7 @@ class TestDrawChart:
     def test_draw_chart_basic(self, test_chart, temp_output_dir):
         """Test basic chart drawing."""
         filepath = os.path.join(temp_output_dir, "test_chart.svg")
-        result = draw_chart(test_chart, filename=filepath, size=600)
+        result = test_chart.draw(filepath).with_size(600).save()
 
         assert result == filepath
         assert os.path.exists(filepath)
@@ -540,63 +539,63 @@ class TestDrawChart:
     def test_draw_chart_custom_size(self, test_chart, temp_output_dir):
         """Test chart drawing with custom size."""
         filepath = os.path.join(temp_output_dir, "test_800.svg")
-        draw_chart(test_chart, filename=filepath, size=800)
+        test_chart.draw(filepath).with_size(800).save()
 
         assert os.path.exists(filepath)
 
     def test_draw_chart_with_moon_phase(self, test_chart, temp_output_dir):
         """Test chart drawing with moon phase."""
         filepath = os.path.join(temp_output_dir, "test_moon.svg")
-        draw_chart(test_chart, filename=filepath, moon_phase=True)
+        test_chart.draw(filepath).with_moon_phase().save()
 
         assert os.path.exists(filepath)
 
     def test_draw_chart_without_moon_phase(self, test_chart, temp_output_dir):
         """Test chart drawing without moon phase."""
         filepath = os.path.join(temp_output_dir, "test_no_moon.svg")
-        draw_chart(test_chart, filename=filepath, moon_phase=False)
+        test_chart.draw(filepath).without_moon_phase().save()
 
         assert os.path.exists(filepath)
 
     def test_draw_chart_with_info(self, test_chart, temp_output_dir):
         """Test chart drawing with chart info."""
         filepath = os.path.join(temp_output_dir, "test_info.svg")
-        draw_chart(test_chart, filename=filepath, chart_info=True)
+        test_chart.draw(filepath).with_chart_info().save()
 
         assert os.path.exists(filepath)
 
     def test_draw_chart_with_aspect_counts(self, test_chart, temp_output_dir):
         """Test chart drawing with aspect counts."""
         filepath = os.path.join(temp_output_dir, "test_aspects.svg")
-        draw_chart(test_chart, filename=filepath, aspect_counts=True)
+        test_chart.draw(filepath).with_aspect_counts().save()
 
         assert os.path.exists(filepath)
 
     def test_draw_chart_with_element_table(self, test_chart, temp_output_dir):
         """Test chart drawing with element/modality table."""
         filepath = os.path.join(temp_output_dir, "test_elements.svg")
-        draw_chart(test_chart, filename=filepath, element_modality_table=True)
+        test_chart.draw(filepath).with_element_modality_table().save()
 
         assert os.path.exists(filepath)
 
     def test_draw_chart_with_chart_shape(self, test_chart, temp_output_dir):
         """Test chart drawing with chart shape."""
         filepath = os.path.join(temp_output_dir, "test_shape.svg")
-        draw_chart(test_chart, filename=filepath, chart_shape=True)
+        test_chart.draw(filepath).with_chart_shape().save()
 
         assert os.path.exists(filepath)
 
     def test_draw_chart_all_features(self, test_chart, temp_output_dir):
         """Test chart drawing with all features enabled."""
         filepath = os.path.join(temp_output_dir, "test_full.svg")
-        draw_chart(
-            test_chart,
-            filename=filepath,
-            moon_phase=True,
-            chart_info=True,
-            aspect_counts=True,
-            element_modality_table=True,
-            chart_shape=True,
+        (
+            test_chart.draw(filepath)
+            .with_moon_phase()
+            .with_chart_info()
+            .with_aspect_counts()
+            .with_element_modality_table()
+            .with_chart_shape()
+            .save()
         )
 
         assert os.path.exists(filepath)
@@ -609,14 +608,14 @@ class TestDrawChart:
     def test_draw_chart_with_theme(self, test_chart, temp_output_dir):
         """Test chart drawing with theme."""
         filepath = os.path.join(temp_output_dir, "test_theme.svg")
-        draw_chart(test_chart, filename=filepath, theme=ChartTheme.DARK)
+        test_chart.draw(filepath).with_theme("dark").save()
 
         assert os.path.exists(filepath)
 
     def test_draw_chart_with_zodiac_palette(self, test_chart, temp_output_dir):
         """Test chart drawing with zodiac palette."""
         filepath = os.path.join(temp_output_dir, "test_palette.svg")
-        draw_chart(test_chart, filename=filepath, zodiac_palette=ZodiacPalette.ELEMENTAL)
+        test_chart.draw(filepath).with_zodiac_palette("elemental").save()
 
         assert os.path.exists(filepath)
 
@@ -634,7 +633,7 @@ class TestDrawChart:
         )
 
         filepath = os.path.join(temp_output_dir, "test_multi_houses.svg")
-        draw_chart(multi_house_chart, filename=filepath)
+        multi_house_chart.draw(filepath).save()
 
         assert os.path.exists(filepath)
 
@@ -656,7 +655,7 @@ class TestVisualizationEdgeCases:
         chart = ChartBuilder.from_native(native).calculate()
 
         filepath = os.path.join(temp_output_dir, "no_aspects.svg")
-        draw_chart(chart, filename=filepath)
+        chart.draw(filepath).save()
 
         assert os.path.exists(filepath)
 
@@ -669,7 +668,7 @@ class TestVisualizationEdgeCases:
         chart = ChartBuilder.from_native(native).calculate()
 
         filepath = os.path.join(temp_output_dir, "minimal.svg")
-        draw_chart(chart, filename=filepath, moon_phase=False, chart_info=False)
+        chart.draw(filepath).without_moon_phase().save()
 
         assert os.path.exists(filepath)
 
@@ -724,7 +723,7 @@ class TestVisualizationPerformance:
         filepath = os.path.join(temp_output_dir, "perf_test.svg")
 
         start = time.time()
-        draw_chart(test_chart, filename=filepath)
+        test_chart.draw(filepath).save()
         elapsed = time.time() - start
 
         # Should complete in under 5 seconds
@@ -735,7 +734,7 @@ class TestVisualizationPerformance:
         """Test creating multiple charts in sequence."""
         for i in range(5):
             filepath = os.path.join(temp_output_dir, f"chart_{i}.svg")
-            draw_chart(test_chart, filename=filepath)
+            test_chart.draw(filepath).save()
             assert os.path.exists(filepath)
 
 
@@ -747,7 +746,7 @@ class TestVisualizationPerformance:
 def test_chart_file_not_empty(test_chart, temp_output_dir):
     """Regression test: Ensure generated SVG files are not empty."""
     filepath = os.path.join(temp_output_dir, "not_empty.svg")
-    draw_chart(test_chart, filename=filepath)
+    test_chart.draw(filepath).save()
 
     file_size = os.path.getsize(filepath)
     assert file_size > 100  # Should be at least 100 bytes
@@ -756,7 +755,7 @@ def test_chart_file_not_empty(test_chart, temp_output_dir):
 def test_svg_well_formed(test_chart, temp_output_dir):
     """Regression test: Ensure SVG is well-formed XML."""
     filepath = os.path.join(temp_output_dir, "well_formed.svg")
-    draw_chart(test_chart, filename=filepath)
+    test_chart.draw(filepath).save()
 
     with open(filepath, "r") as f:
         content = f.read()


### PR DESCRIPTION
BREAKING CHANGE: Removed all references to the deleted visualization/drawing.py module

Changes:
- Updated all code files to use the new fluent builder API:
  * draw_chart(chart, "file.svg", ...) → chart.draw("file.svg").with_X(...).save()
  * draw_comparison_chart(comparison, ...) → comparison.draw(...).save()

Files updated:
- src/starlight/cli/chart.py: Updated CLI to use chart.draw().save()
- tests/test_visualization.py: Converted 20+ test functions to new API
- examples/: Updated 8 example files (viz, theming, biwheel, palettes, etc.)
- src/starlight/__init__.py: Removed commented imports, updated docstring examples
- src/starlight/visualization/__init__.py: Cleaned up commented exports
- CLAUDE.md: Updated documentation to reflect new API

The old draw_chart() and draw_comparison_chart() functions from the deleted visualization/drawing.py module have been fully replaced with the new ChartDrawBuilder fluent API accessed via chart.draw() and comparison.draw().