### PR TITLE
ci: build Sphinx docs in Docs Validation to catch breaks at PR time

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,3 +28,13 @@ jobs:
 
     - name: Run documentation validation
       run: pytest -m "docs or notebooks"
+
+    # Build the Sphinx site so a sphinx/plugin break is caught at PR time.
+    # Read the Docs only builds after merge to main, so without this a broken
+    # docs build would land before anyone notices. Non-strict (no -W): the site
+    # currently emits many pre-existing warnings, so we fail only on hard build
+    # errors, not warnings.
+    - name: Build Sphinx docs
+      run: |
+        pip install -r docs/requirements.txt
+        python -m sphinx -b html docs docs/_build/html


### PR DESCRIPTION
## Problem

Read the Docs is **not** configured to build pull requests — it only builds after merge to `main` (confirmed: dependabot PR #41 shows 9 `test` jobs + 1 `docs` job, no `docs/readthedocs.org` check). And the existing **Docs Validation** job only runs `pytest -m "docs or notebooks"`, which exercises doc code blocks, cookbook scripts, and notebooks — it never installs `docs/requirements.txt` or runs `sphinx-build`.

Net effect: a sphinx- or plugin-breaking change can merge green and only surface on the published RTD site *after* merge.

## Change

Add a `Build Sphinx docs` step to the Docs Validation job that installs `docs/requirements.txt` and runs `sphinx -b html docs docs/_build/html`, mirroring how RTD builds.

- **Non-strict (no `-W`)** on purpose: the site currently emits ~214 pre-existing warnings, so warnings-as-errors would be red on day one. This catches *hard* build failures (e.g., a future sphinx 10 / `sphinx-autodoc-typehints` API break).
- Adds ~1 min to the already-existing docs job.

## Verification

Built locally mirroring RTD (`pip install -r docs/requirements.txt -e .`, then `sphinx -b html docs`): `build succeeded`, exit 0, `index.html` produced (with sphinx 9.0.4, the current resolved version).

## Follow-up (not in this PR)

Once the pre-existing warnings are burned down, a strict (`-W`) variant could be added so broken cross-references also fail the build.