### PR TITLE
ci(release): fail loudly if built version != release tag

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,6 +31,20 @@ jobs:
     - name: Build package
       run: python -m build
 
+    - name: Verify built version matches the release tag
+      # The package version is dynamic (attr = stellium.__version__). If the tag
+      # is bumped but __version__ is not, the build silently produces the OLD
+      # version and PyPI rejects it as a duplicate. Fail loudly here instead.
+      run: |
+        built=$(ls dist/*.whl | sed -E 's|.*/stellium-([^-]+)-py3.*|\1|')
+        tag="${GITHUB_REF_NAME#v}"
+        echo "built wheel version: $built"
+        echo "release tag version: $tag"
+        if [ "$built" != "$tag" ]; then
+          echo "::error::Built version ($built) does not match release tag ($tag). Did you forget to bump src/stellium/__init__.py __version__?"
+          exit 1
+        fi
+
     - name: Check package
       run: twine check dist/*
 


### PR DESCRIPTION
## Why

The `v0.21.0` release failed to publish to PyPI. Root cause: the package version is dynamic (`version = { attr = "stellium.__version__" }`), but `__version__` was left at `"0.20.0"` when the tag was bumped to `v0.21.0`. The build silently produced a **0.20.0** artifact, and PyPI rejected it as a duplicate (0.20.0 already exists). Nothing warned before the upload attempt.

## What

Adds a post-build step to `publish-to-pypi.yml` that compares the built wheel's version against the release tag (`GITHUB_REF_NAME` minus the leading `v`) and fails with an actionable message *before* the PyPI upload:

```
::error::Built version (0.20.0) does not match release tag (0.21.0).
Did you forget to bump src/stellium/__init__.py __version__?
```

## Verification

Tested the extraction/comparison against a real wheel filename (`stellium-0.21.0-py3-none-any.whl`):
- tag `v0.21.0` → **MATCH** (proceeds)
- tag `v0.20.0` → **MISMATCH** (fails loudly)

i.e. it would have caught the exact failure that motivated it.