### PR TITLE
ci: cache pip installs + cancel superseded PR runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancel superseded runs on the same PR/branch to save minutes, but let main runs
+# finish so every merged commit is validated on the record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -17,6 +23,10 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          docs/requirements.txt
 
     - name: Install system dependencies
       run: sudo apt-get install -y graphviz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancel superseded runs on the same PR/branch to save minutes, but let main runs
+# finish so every merged commit is validated on the record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -25,6 +31,8 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: pyproject.toml
 
     - name: Install dependencies
       run: |
@@ -73,6 +81,8 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: pyproject.toml
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Same coverage, less wall-clock — two cheap wins on the existing workflows.

**pip caching** (`actions/setup-python` `cache: 'pip'`) on every job that installs — the 3×3 test matrix, web-tests, and docs, keyed on `pyproject.toml` (plus `docs/requirements.txt` for docs). Each job was doing a cold `pip install -e .[dev]` from scratch; now the wheel cache is reused across runs. `i18n-coverage` is left uncached on purpose — it's pure-stdlib and installs nothing.

**concurrency + cancel-in-progress** on PR/feature branches, so pushing twice in quick succession kills the stale run instead of racing two full 12-check runs. `main` is excluded from cancellation, so every merged commit stays fully validated on the record.

No coverage removed — the 3-OS × 3-Python matrix stays; it earns its keep (a Windows-only font-path bug and a Linux/macOS row-ordering bug both shipped through gaps it now guards).

_Note: this PR's own first run is a cache **miss** (it populates the cache); the speedup shows on the run after._