### PR TITLE
fix(config): include Hygiea in comprehensive()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`zh_CN` rendered the planet Earth as the element** (`土象`) rather than `地球`, because the previous translation layer looked terms up by English string with no namespace, so `Earth` the body and `Earth` the element collided. Terms are now namespaced.
 - **The markdown/text report dropped a compound section nested in a compound**, rendering it as `*Unknown type: compound*` — the zodiacal-releasing snapshot hit this. The renderer now recurses (the PDF path already did), so the snapshot's inner tables render.
+- **`CalculationConfig.comprehensive()` silently omitted Hygiea** — Ceres, Pallas, Juno and Vesta all resolved, but Hygiea (the fourth-largest asteroid, fifth of the classical "big five") was absent. Its Swiss Ephemeris id was corrected in 0.22.0, so it now belongs in the set and computes.
 
 ## [0.22.0] - 2026-07-14
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 ## High
 
 - Fix broad exception swallowing (30+ bare except clauses)
+- Regenerate all README and example images
 - Resolve Comparison vs MultiChart API duality
 - Zodiacal Releasing engine rewrite (parameterized, preset-based) `in-progress`
 
@@ -19,18 +20,17 @@
 - BaZi: Clashes, combinations, and penalties
 - Build plugin ecosystem architecture (Phase 3 of VISION)
 - DX: surface silent None returns from component-dependent accessors
-- Dispositor graph in PDF: fix residual glyph tofu + make themeable.
 - Evaluate component/analyzer support for non-ChartBuilder chart types
+- Finalize new Planner redesigned
 - Fix aspect-pattern over-counting on conjunct points
 - Gauquelin sectors as an analysis primitive (gauquelin_sector) + Mars-effect study on notables DB
 - Implement Vedic dignities engine (moolatrikona, Dig Bala, Navamsa)
 - Implement Vimshottari Dasha system
 - Implement horary astrology (querent/quesited, radicality, considerations before judgement)
 - Implement interactive HTML reports (Jinja2 + Pico.css)
-- Integrate Simplified Chinese translation strings into main library and web
 - Optimize 'stellium cache info' — get_stats() walks the whole cache dir (slow/hangs on large caches)
 - PDF table zebra: decide flat vs full-bleed.
-- Structure-first section contract
+- Redesign the chart wheel images
 - Update COMPETITIVE_ANALYSIS.md — house exports done, re-evaluate gaps
 - Update chart grid to accept arbitrary wheel-only charts
 - Uranian dial chart info header

--- a/src/stellium/core/config.py
+++ b/src/stellium/core/config.py
@@ -89,5 +89,16 @@ class CalculationConfig:
             include_nodes=True,
             include_chiron=True,
             include_points=["Mean Apogee", "True Apogee"],  # Both Liliths
-            include_asteroids=["Chiron", "Pholus", "Ceres", "Pallas", "Juno", "Vesta"],
+            # The big-four asteroids plus Hygiea (the fourth-largest, and the fifth of the
+            # classical "big five"); Hygiea was silently absent until its Swiss Ephemeris
+            # id was corrected. Chiron/Pholus are the centaurs.
+            include_asteroids=[
+                "Chiron",
+                "Pholus",
+                "Ceres",
+                "Pallas",
+                "Juno",
+                "Vesta",
+                "Hygiea",
+            ],
         )

--- a/tests/test_celestial_registry.py
+++ b/tests/test_celestial_registry.py
@@ -311,3 +311,14 @@ def test_gonggong_is_registered_with_its_glyph():
     gonggong = CELESTIAL_REGISTRY["Gonggong"]
     assert gonggong.glyph_svg_path == "gonggong.svg"
     assert get_glyph("Gonggong")["type"] == "svg"
+
+
+def test_comprehensive_config_includes_hygiea():
+    """Regression: Hygiea — the fourth-largest asteroid and fifth of the classical "big
+    five" — was silently absent from ``CalculationConfig.comprehensive()`` while Ceres,
+    Pallas, Juno and Vesta all resolved. Its Swiss Ephemeris id is now correct (see the
+    ground-truth suite), so it belongs in the set.
+    """
+    from stellium.core.config import CalculationConfig
+
+    assert "Hygiea" in CalculationConfig.comprehensive().include_asteroids


### PR DESCRIPTION
`CalculationConfig.comprehensive()` requested Ceres, Pallas, Juno and Vesta but silently omitted **Hygiea** — the fourth-largest asteroid, fifth of the classical "big five." Its Swiss Ephemeris id was corrected in 0.22.0 (Horizons-validated), so it resolves cleanly the moment it's requested; this adds it to `include_asteroids`.

Verified: a comprehensive chart now returns Hygiea (≈11° Pisces for Einstein, no warnings). Regression test guards the config set; the position is already covered by the ground-truth suite. Closes the backlog task.