### PR TITLE
chore: make TODO.md sync a non-blocking post-commit reminder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,23 @@ repos:
 
   - repo: local
     hooks:
+      # POST-commit, deliberately (same reasoning as docs-staleness below). TODO.md
+      # mirrors an *external* system — the Obsidian vault — so it changes whenever the
+      # vault changed, not when your code did. A modifying hook at the pre-commit/pre-push
+      # stage ALWAYS fails (the framework re-stages formatter output that way), so this one
+      # used to block every commit made after any Obsidian activity. Here it only runs
+      # `--check` (read-only): it prints a nudge if TODO.md is stale and never fails.
+      # The actual sync is deliberate — run `python scripts/sync_todo.py` when tasks change.
+      # Install with:  pre-commit install --hook-type post-commit
       - id: sync-todo
-        name: Sync TODO.md from Obsidian
-        entry: python scripts/sync_todo.py
+        name: TODO.md freshness reminder
+        stages: [post-commit]
+        entry: python scripts/sync_todo.py --check
         language: python
         additional_dependencies: [pyyaml]
         pass_filenames: false
         always_run: true
+        verbose: true
 
       # POST-commit, deliberately. It cannot block a commit and cannot fail a push —
       # it prints a reminder or it says nothing. Install with:

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,11 @@
 # TODO
 
-*42 open tasks (synced from Obsidian)*
+*41 open tasks (synced from Obsidian)*
 
 ## High
 
 - Fix broad exception swallowing (30+ bare except clauses)
+- Regenerate all README and example images
 - Resolve Comparison vs MultiChart API duality
 - Zodiacal Releasing engine rewrite (parameterized, preset-based) `in-progress`
 
@@ -19,18 +20,17 @@
 - BaZi: Clashes, combinations, and penalties
 - Build plugin ecosystem architecture (Phase 3 of VISION)
 - DX: surface silent None returns from component-dependent accessors
-- Dispositor graph in PDF: fix residual glyph tofu + make themeable.
 - Evaluate component/analyzer support for non-ChartBuilder chart types
+- Finalize new Planner redesigned
 - Fix aspect-pattern over-counting on conjunct points
 - Gauquelin sectors as an analysis primitive (gauquelin_sector) + Mars-effect study on notables DB
 - Implement Vedic dignities engine (moolatrikona, Dig Bala, Navamsa)
 - Implement Vimshottari Dasha system
 - Implement horary astrology (querent/quesited, radicality, considerations before judgement)
 - Implement interactive HTML reports (Jinja2 + Pico.css)
-- Integrate Simplified Chinese translation strings into main library and web
 - Optimize 'stellium cache info' — get_stats() walks the whole cache dir (slow/hangs on large caches)
 - PDF table zebra: decide flat vs full-bleed.
-- Structure-first section contract
+- Redesign the chart wheel images
 - Update COMPETITIVE_ANALYSIS.md — house exports done, re-evaluate gaps
 - Update chart grid to accept arbitrary wheel-only charts
 - Uranian dial chart info header
@@ -43,7 +43,6 @@
 - Build research platform (hypothesis testing, batch analysis)
 - Cross-tradition chart synthesis (Western + Vedic + Chinese unified view)
 - Greyscale PDF theme: fully grey the embedded chart wheel.
-- Hygiea silently absent from CalculationConfig.comprehensive()
 - Reconcile Carl Jung notable record (time + data quality)
 - Refactor SectionData to sealed dataclass hierarchy
 - Topocentric parallax corrections

--- a/scripts/sync_todo.py
+++ b/scripts/sync_todo.py
@@ -86,8 +86,8 @@ def collect_tasks() -> list[dict]:
     return tasks
 
 
-def write_todo(tasks: list[dict]) -> None:
-    """Write tasks to TODO.md."""
+def render_todo(tasks: list[dict]) -> str:
+    """Render the tasks to TODO.md content (does not write)."""
     lines = ["# TODO", "", f"*{len(tasks)} open tasks (synced from Obsidian)*", ""]
 
     # Group by priority
@@ -106,15 +106,39 @@ def write_todo(tasks: list[dict]) -> None:
         lines.append(f"- {task['title']}{due}{status_tag}")
 
     lines.append("")
-    TODO_PATH.write_text("\n".join(lines), encoding="utf-8")
-    print(f"Wrote {len(tasks)} tasks to {TODO_PATH}")
+    return "\n".join(lines)
+
+
+def main(check: bool) -> int:
+    """Write TODO.md, or (``--check``) only nudge if it is stale.
+
+    ``--check`` is read-only and always exits 0 — it is the post-commit reminder, so it
+    can never block a commit or fail a push. Plain (write) mode is the deliberate sync,
+    run when tasks actually change.
+    """
+    if not VAULT_TASKS_DIR.exists():
+        # Vault not present (CI, other machine) -- nothing to sync or check.
+        if not check:
+            print("Obsidian vault not found, skipping TODO sync")
+        return 0
+
+    content = render_todo(collect_tasks())
+    current = TODO_PATH.read_text(encoding="utf-8") if TODO_PATH.exists() else ""
+
+    if check:
+        if content != current:
+            print(
+                "TODO.md is out of sync with the Obsidian vault — run "
+                "`python scripts/sync_todo.py` to refresh it."
+            )
+        return 0  # never blocks
+
+    TODO_PATH.write_text(content, encoding="utf-8")
+    print(f"Wrote {content.count(chr(10) + '- ')} tasks to {TODO_PATH}")
+    return 0
 
 
 if __name__ == "__main__":
-    if not VAULT_TASKS_DIR.exists():
-        # Vault not present (CI, other machine) -- skip silently
-        print("Obsidian vault not found, skipping TODO sync")
-        raise SystemExit(0)
+    import sys
 
-    tasks = collect_tasks()
-    write_todo(tasks)
+    raise SystemExit(main(check="--check" in sys.argv))


### PR DESCRIPTION
The `sync-todo` hook mirrors the Obsidian vault into `TODO.md`, but it ran at the pre-commit/pre-push stage and **modified** `TODO.md` — which the pre-commit framework treats as a failure (that's how it re-stages formatter output). So it blocked every commit/push made after any Obsidian activity, and the count flapped as the TaskNotes cache settled.

Now it follows the same **post-commit, never-blocking** pattern as `docs-staleness`: `sync_todo.py` gains a read-only `--check` mode that only nudges when `TODO.md` is stale (always exits 0), and the hook runs it at `stages: [post-commit]`. The actual sync stays deliberate — run `python scripts/sync_todo.py` when tasks change.

Verified: commits and pushes no longer block; the post-commit run shows `TODO.md freshness reminder... Passed`. This commit also refreshes `TODO.md` for the tasks closed today.