### PR TITLE
feat(core): aspects on by default (+ .without_aspects() opt-out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Aspects are computed by default.** `ChartBuilder.from_native(native).calculate()` now populates `chart.aspects` (via `ModernAspectEngine`), matching the ephemeris, houses and orbs — all of which were already on by default. Previously aspects alone were opt-in, so a bare chart silently had `chart.aspects == []`, and a report's aspect list / aspectarian / patterns rendered empty unless you remembered `.with_aspects()`. **This changes results on upgrade**: code that relied on a bare chart having no aspects now sees them. Opt out with the new **`.without_aspects()`** where you never read them (batch position analysis, ephemeris sweeps) to skip the O(n²) pass; the built-in batch calculator and the void-of-course search already do.
+
 - **The element/modality table on charts is now glyph-based.** The column headers use the Cardinal/Fixed/Mutable glyphs and each row its element symbol, rather than the words "Card/Fix/Mut" and two-letter abbreviations — so the table reads the same in every language and needs no translation.
 - **Essential-dignity names are capitalized** in the `show_details` view — "Peregrine, Detriment" rather than "peregrine, detriment", the standard convention (the lowercase was the engine's internal form leaking into display). Compound dignities now read as "Exaltation (exact)" / "Participating Ruler" / "Triplicity (participating)" rather than the raw `Exaltation_Exact` / `Participating_Ruler` keys.
 - **Every house system has a distinct short-form abbreviation.** A 4-character truncating fallback previously collided — `Equal (MC)` and `Equal (Vertex)` both rendered as `Equa`; they are now `EqMC` and `EqVx`.

--- a/src/stellium/analysis/batch.py
+++ b/src/stellium/analysis/batch.py
@@ -279,10 +279,14 @@ class BatchCalculator:
         # Configure house systems
         builder.with_house_systems(self._house_engines)
 
-        # Configure aspects (if enabled)
+        # Configure aspects (opt-in for batch). ChartBuilder is aspects-on by default,
+        # so explicitly opt out when the batch didn't request them — this preserves the
+        # BatchCalculator's own toggle and skips the per-chart O(n²) pass at scale.
         if self._aspect_engine:
             builder.with_aspects(self._aspect_engine)
             builder.with_orbs(self._orb_engine)
+        else:
+            builder.without_aspects()
 
         # Add analyzers
         for analyzer in self._analyzers:

--- a/src/stellium/core/builder.py
+++ b/src/stellium/core/builder.py
@@ -75,10 +75,13 @@ class ChartBuilder:
         self._location = location
         self.native = native  # Store Native for reference
 
-        # Default engines (can be overridden)
+        # Default engines (can be overridden). Aspects are on by default — like the
+        # ephemeris, houses and orbs — because a natal chart without them is a
+        # surprise; `.without_aspects()` opts out (batch/analysis that never reads
+        # `chart.aspects`).
         self._ephemeris: EphemerisEngine = SwissEphemerisEngine()
         self._house_engines: list[HouseSystemEngine] = [PlacidusHouses()]
-        self._aspect_engine: AspectEngine | None = None  # optional
+        self._aspect_engine: AspectEngine | None = ModernAspectEngine()
         self._orb_engine: OrbEngine = SimpleOrbEngine()
 
         # Configuration
@@ -338,8 +341,22 @@ class ChartBuilder:
         return self
 
     def with_aspects(self, engine: AspectEngine | None = None) -> "ChartBuilder":
-        """Set the aspect calculation engine."""
+        """Set the aspect calculation engine.
+
+        Aspects are computed by default (with :class:`ModernAspectEngine`), so call
+        this only to supply a *different* engine. To turn aspects off, use
+        :meth:`without_aspects`.
+        """
         self._aspect_engine = engine or ModernAspectEngine()
+        return self
+
+    def without_aspects(self) -> "ChartBuilder":
+        """Skip aspect calculation, leaving ``chart.aspects`` empty.
+
+        Aspects are on by default. Opt out when you never read them — batch position
+        analysis, ephemeris sweeps — to save the O(n²) pairwise pass.
+        """
+        self._aspect_engine = None
         return self
 
     def with_orbs(self, engine: OrbEngine | None = None) -> "ChartBuilder":

--- a/src/stellium/electional/intervals.py
+++ b/src/stellium/electional/intervals.py
@@ -603,7 +603,9 @@ def _find_voc_transition_in_sign(
         dt = _julian_day_to_datetime(jd)
         # Use a neutral location for VOC calculation (doesn't matter for Moon aspects)
         native = Native(dt, (0.0, 0.0))  # (latitude, longitude) tuple
-        chart = ChartBuilder.from_native(native).calculate()
+        # voc_moon computes its own forward-aspect scan and never reads chart.aspects,
+        # so skip the now-default aspect pass — this runs in a per-JD search loop.
+        chart = ChartBuilder.from_native(native).without_aspects().calculate()
         result = chart.voc_moon(aspects=mode)
         return result.is_void
 

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -151,13 +151,16 @@ def test_internal_aspects_calculated_if_missing():
     """Test that internal aspects are calculated if charts don't have them."""
     loc = ChartLocation(latitude=40.7128, longitude=-74.0060, name="New York")
 
-    # Create charts WITHOUT aspects
+    # Create charts WITHOUT aspects (aspects are on by default now, so opt out).
     native_a = Native(datetime(1990, 1, 1, 12, 0, tzinfo=dt.UTC), loc)
-    chart_a_no_aspects = ChartBuilder.from_native(native_a).calculate()
-    # Note: Currently ChartBuilder doesn't calculate aspects by default (aspects OFF)
+    chart_a_no_aspects = (
+        ChartBuilder.from_native(native_a).without_aspects().calculate()
+    )
 
     native_b = Native(datetime(1995, 6, 15, 14, 30, tzinfo=dt.UTC), loc)
-    chart_b_no_aspects = ChartBuilder.from_native(native_b).calculate()
+    chart_b_no_aspects = (
+        ChartBuilder.from_native(native_b).without_aspects().calculate()
+    )
 
     # Verify charts don't have aspects
     assert len(chart_a_no_aspects.aspects) == 0

--- a/tests/test_i18n_foundations.py
+++ b/tests/test_i18n_foundations.py
@@ -183,7 +183,11 @@ def test_english_report_byte_identical():
     it is a bug. (The zh_CN report is *meant* to change as leaks are fixed — that is
     asserted separately, by rendered content rather than a hash that would churn.)
     """
-    chart = ChartBuilder.from_notable("Albert Einstein").calculate()
+    # Aspects are on by default now; opt out so this fixture matches the state the
+    # golden hash was captured against (an empty aspect section). This keeps the test
+    # a pure i18n invariant — proving the migration didn't move English — rather than
+    # churning it on an unrelated feature that merely adds aspect rows.
+    chart = ChartBuilder.from_notable("Albert Einstein").without_aspects().calculate()
     got = hashlib.sha1(_report(chart, "en").encode()).hexdigest()
     assert got == "d7349ef80c503871fc3b49bb1358020db06a981a", (
         f"English report changed (now {got}) — the migration must not touch English"


### PR DESCRIPTION
## Aspects on by default (fix the empty-aspects footgun)

`ChartBuilder` defaulted the ephemeris, houses, and orbs to real engines but left the **aspect engine** as `None` — the lone opt-in. So a bare `ChartBuilder.from_native(native).calculate()` silently produced `chart.aspects == []`, and a report's aspect list / aspectarian / patterns rendered empty unless you remembered `.with_aspects()`. This bit us during the PDF revamp (an empty aspectarian on a chart that "should" have had aspects).

Aspects now default to `ModernAspectEngine()`, consistent with the other three engines. New **`.without_aspects()`** opts out where they're never read, to skip the O(n²) pairwise pass.

### Changes
- `ChartBuilder`: default `_aspect_engine = ModernAspectEngine()`; add `without_aspects()`; docstring on `with_aspects()` notes it's now for supplying a *different* engine.
- `BatchCalculator`: preserves its own opt-in aspect toggle (it was relying on the old ChartBuilder default) by calling `.without_aspects()` when no batch aspect engine is set — batch stays lean at scale.
- Void-of-course search (`electional/intervals.py`): opts out — `voc_moon()` runs its own forward-aspect scan, never reads `chart.aspects`, and runs in a per-JD search loop.

### Behavior change (noted in CHANGELOG)
`chart.aspects` is now populated on a bare chart. Two tests deliberately built no-aspect fixtures and now use `.without_aspects()`:
- the comparison internal-aspect-fallback test (still verifies the comparison fills aspects when inputs lack them);
- the i18n English-byte-identity golden — **hash preserved**, which proves this change adds *data* without touching any English rendering *path*.

Full suite green (only the 10 intentional skips); ruff clean.

Closes the "Aspects on by default in ChartBuilder" backlog task.
